### PR TITLE
return unpooled features from forward_features and added forward_head like timm

### DIFF
--- a/fastervit/models/faster_vit.py
+++ b/fastervit/models/faster_vit.py
@@ -947,13 +947,17 @@ class FasterViT(nn.Module):
         for level in self.levels:
             x = level(x)
         x = self.norm(x)
+        return x
+    
+    def forward_head(self, x):
         x = self.avgpool(x)
         x = torch.flatten(x, 1)
+        x = self.head(x)
         return x
 
     def forward(self, x):
         x = self.forward_features(x)
-        x = self.head(x)
+        x = self.forward_head(x)
         return x
     
     def _load_state_dict(self, 

--- a/fastervit/models/faster_vit_any_res.py
+++ b/fastervit/models/faster_vit_any_res.py
@@ -977,7 +977,6 @@ class FasterViT(nn.Module):
         for level in self.levels:
             x = level(x)
         x = self.norm(x)
-        
         return x
     
     def forward_head(self, x):

--- a/fastervit/models/faster_vit_any_res.py
+++ b/fastervit/models/faster_vit_any_res.py
@@ -977,13 +977,18 @@ class FasterViT(nn.Module):
         for level in self.levels:
             x = level(x)
         x = self.norm(x)
+        
+        return x
+    
+    def forward_head(self, x):
         x = self.avgpool(x)
         x = torch.flatten(x, 1)
+        x = self.head(x)
         return x
 
     def forward(self, x):
         x = self.forward_features(x)
-        x = self.head(x)
+        x = self.forward_head(x)
         return x
     
     def _load_state_dict(self, 


### PR DESCRIPTION
Thanks for sharing your work!

Unpooled features are returned from forward_features, and forward_head has been added like timm to keep timm's original design.

![image](https://github.com/NVlabs/FasterViT/assets/35001605/d1995c41-ff48-446a-bdeb-826a2185d7cc)
